### PR TITLE
Allow `mark_unknown` to be actually used in `translate`

### DIFF
--- a/apertium/translation/__init__.py
+++ b/apertium/translation/__init__.py
@@ -146,7 +146,7 @@ class Translator:
             result = re.sub(rb'\0$', b'', text)  # type: ignore
         return result
 
-    def translate(self, text: str, mark_unknown: bool = False, formatting: Optional[str] = None, deformat: str = 'txt', reformat: str = 'txt') -> str:
+    def translate(self, text: str, mark_unknown: bool = True, formatting: Optional[str] = None, deformat: str = 'txt', reformat: str = 'txt') -> str:
         """
         Args:
             text (str)
@@ -174,7 +174,7 @@ class Translator:
             return result.decode()
 
 
-def translate(lang1: str, lang2: str, text: str, mark_unknown: bool = False,
+def translate(lang1: str, lang2: str, text: str, mark_unknown: bool = True,
               formatting: Optional[str] = None, deformat: str = 'txt', reformat: str = 'txt') -> str:
     """
     Args:

--- a/apertium/utils.py
+++ b/apertium/utils.py
@@ -3,7 +3,7 @@ import platform
 import subprocess
 import sys
 import tempfile
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union, Optional
 
 try:
     if platform.system() == 'Linux':
@@ -176,7 +176,7 @@ def execute_pipeline(inp: str, commands: List[List[str]]) -> str:
     return end.decode()
 
 
-def parse_mode_file(mode_path: str) -> List[List[str]]:
+def parse_mode_file(mode_path: str, option: Optional[List[str]], option_tagger: Optional[List[str]]) -> List[List[str]]:
     """
     Args:
         mode_path (str)
@@ -184,6 +184,12 @@ def parse_mode_file(mode_path: str) -> List[List[str]]:
     Returns:
         List[List[str]]
     """
+
+    if option is None:
+        option = ['-g']
+    if option_tagger is None:
+        option_tagger = []
+
     with open(mode_path) as mode_file:
         mode_str = mode_file.read().strip()
     if mode_str:
@@ -192,7 +198,8 @@ def parse_mode_file(mode_path: str) -> List[List[str]]:
             # TODO: we should make language pairs install
             # modes.xml instead; this is brittle (what if a path
             # has | or ' in it?)
-            cmd = cmd.replace('$2', '').replace('$1', '-g')
+            cmd = cmd.replace('$1', ' '.join(option))
+            cmd = cmd.replace('$2', ' '.join(option_tagger))
             commands.append([c.strip("'") for c in cmd.split()])
         return commands
     else:


### PR DESCRIPTION
Fixes #82
The option for `mark_unknown` translation was present but not used. This code fixes that.
It also clarifies the role of `$1` and `$2` (variable names come from apertium CLI) in `parse_mode_file`.

This function was untested for the wrapper because I couldn't make it work. For information: in #82 dimitarsh1 dealt with that by prevented using the wrapper when `mark_unknown` was used.
